### PR TITLE
Add first simple implementation for the CmsRouter

### DIFF
--- a/MISSINGTESTS.md
+++ b/MISSINGTESTS.md
@@ -38,3 +38,11 @@
     * the locale will be set on user language
 * Post
     * it syncs the tags automatically
+* CmsRouter
+    * blog routes will be registered
+    * blog prefix will be set
+    * blog middleware will be set
+    * page slugs will be cached
+    * page routes will be registered
+    * page prefix will be set
+    * page middleware will be set

--- a/config/config.php
+++ b/config/config.php
@@ -14,4 +14,10 @@ return [
         'main' => [],
         'footer' => [],
     ],
+    'blog' => [
+        'middleware' => 'web',
+    ],
+    'pages' => [
+        'middleware' => 'web',
+    ]
 ];

--- a/resources/views/blog/index.blade.php
+++ b/resources/views/blog/index.blade.php
@@ -1,0 +1,1 @@
+<h1>blog index page</h1>

--- a/resources/views/blog/show.blade.php
+++ b/resources/views/blog/show.blade.php
@@ -1,0 +1,1 @@
+<h1>blog single page</h1>

--- a/resources/views/pages/show.blade.php
+++ b/resources/views/pages/show.blade.php
@@ -1,0 +1,1 @@
+<h1>single page</h1>

--- a/src/Http/Controllers/BlogController.php
+++ b/src/Http/Controllers/BlogController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Bambamboole\LaravelCms\Http\Controllers;
+
+use Bambamboole\LaravelCms\Models\Post;
+
+class BlogController
+{
+    public function index()
+    {
+        return view('cms::blog.index', ['posts' => Post::all()]);
+    }
+
+    public function show(string $slug)
+    {
+        return view('cms::blog.show', ['posts' => Post::query()->where('slug', $slug)->firstOrFail()]);
+    }
+}

--- a/src/Services/CmsRouter.php
+++ b/src/Services/CmsRouter.php
@@ -21,18 +21,6 @@ class CmsRouter
         $this->config = $config;
     }
 
-    public function registerBlogRoutes(string $pathPrefix = 'blog')
-    {
-        $this->router
-            ->middleware([$this->config->get('cms.blog.middleware'), SetLocale::class])
-            ->prefix($pathPrefix)
-            ->as('cms.')
-            ->group(function (Router $router) {
-                $router->get('/', [BlogController::class, 'index'])->name('blog.index');
-                $router->get('/{$slug}', [BlogController::class, 'index'])->name('blog.index');
-            });
-    }
-
     public function registerPageRoutes(string $pathPrefix = '')
     {
         $slugs = Cache::rememberForever('cms.slugs', function () {
@@ -45,8 +33,20 @@ class CmsRouter
             ->as('cms.')
             ->group(function (Router $router) use ($slugs) {
                 $slugs->each(function (string $slug) use ($router) {
-                    $router->get("/{$slug}", [PageRenderer::class, 'render']);
+                    $router->get("/{$slug}", [PageRenderer::class, 'render'])->name("pages.{$slug}");
                 });
+            });
+    }
+
+    public function registerBlogRoutes(string $pathPrefix = 'blog')
+    {
+        $this->router
+            ->middleware([$this->config->get('cms.blog.middleware'), SetLocale::class])
+            ->prefix($pathPrefix)
+            ->as('cms.')
+            ->group(function (Router $router) {
+                $router->get('/', [BlogController::class, 'index'])->name('blog.index');
+                $router->get('/{$slug}', [BlogController::class, 'index'])->name('blog.index');
             });
     }
 }

--- a/src/Services/CmsRouter.php
+++ b/src/Services/CmsRouter.php
@@ -40,7 +40,7 @@ class CmsRouter
         });
 
         $this->router
-            ->middleware([$this->config->get('cms.blog.middleware'), SetLocale::class])
+            ->middleware([$this->config->get('cms.pages.middleware'), SetLocale::class])
             ->prefix($pathPrefix)
             ->as('cms.')
             ->group(function (Router $router) use ($slugs) {

--- a/src/Services/CmsRouter.php
+++ b/src/Services/CmsRouter.php
@@ -1,0 +1,54 @@
+<?php
+
+
+namespace Bambamboole\LaravelCms\Services;
+
+
+use Bambamboole\LaravelCms\Http\Controllers\BlogController;
+use Bambamboole\LaravelCms\Http\Middleware\SetLocale;
+use Bambamboole\LaravelCms\Models\Page;
+use Illuminate\Config\Repository;
+use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Cache;
+
+class CmsRouter
+{
+    protected Router $router;
+
+    protected Repository $config;
+
+    public function __construct(Router $router, Repository $config)
+    {
+        $this->router = $router;
+        $this->config = $config;
+    }
+
+    public function registerBlogRoutes(string $pathPrefix = 'blog')
+    {
+        $this->router
+            ->middleware([$this->config->get('cms.blog.middleware'), SetLocale::class])
+            ->prefix($pathPrefix)
+            ->as('cms.')
+            ->group(function (Router $router) {
+                $router->get('/', [BlogController::class, 'index'])->name('blog.index');
+                $router->get('/{$slug}', [BlogController::class, 'index'])->name('blog.index');
+            });
+    }
+
+    public function registerPageRoutes(string $pathPrefix = 'blog')
+    {
+        $slugs = Cache::rememberForever('cms.slugs', function () {
+            return Page::query()->get('slug');
+        });
+
+        $this->router
+            ->middleware([$this->config->get('cms.blog.middleware'), SetLocale::class])
+            ->prefix($pathPrefix)
+            ->as('cms.')
+            ->group(function (Router $router) use ($slugs) {
+                $slugs->each(function (string $slug) use ($router) {
+                    $router->get("/{$slug}", [PageRenderer::class, 'render']);
+                });
+            });
+    }
+}

--- a/src/Services/CmsRouter.php
+++ b/src/Services/CmsRouter.php
@@ -35,7 +35,7 @@ class CmsRouter
             });
     }
 
-    public function registerPageRoutes(string $pathPrefix = 'blog')
+    public function registerPageRoutes(string $pathPrefix = '')
     {
         $slugs = Cache::rememberForever('cms.slugs', function () {
             return Page::query()->get('slug');

--- a/src/Services/PageRenderer.php
+++ b/src/Services/PageRenderer.php
@@ -1,0 +1,19 @@
+<?php
+
+
+namespace Bambamboole\LaravelCms\Services;
+
+
+use Bambamboole\LaravelCms\Models\Page;
+use Illuminate\Http\Request;
+
+class PageRenderer
+{
+    public function render(Request $request)
+    {
+        $slug = end(explode('/', $request->path()));
+        $page = Page::query()->where('slug', $slug)->firstOrFail();
+
+        return view('cms::pages.show', ['page' => $page]);
+    }
+}

--- a/src/Services/PageRenderer.php
+++ b/src/Services/PageRenderer.php
@@ -9,7 +9,7 @@ class PageRenderer
 {
     public function render(Request $request)
     {
-        $slug = end(explode('/', $request->path()));
+        $slug = end(explode('.', $request->route()->getName()));
         $page = Page::query()->where('slug', $slug)->firstOrFail();
 
         return view('cms::pages.show', ['page' => $page]);


### PR DESCRIPTION
This PR adds a simple router for pages and posts.   
It caches the slugs of all pages before it registers the routes.

The routes are not activated by default. They needs to be activated in the Laravel application.
I just pushed it to the b5 environment: https://github.com/bambamboole/laravel-cms-b5-environment/commit/4edb57ea5ffae7cb1fceeec0c47d73730531e9c0

Resolves #42 
